### PR TITLE
fix: workshop 6.0.0 compat

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -110,12 +110,3 @@ class HelloWorldSkill(OVOSSkill):
         #                  and is non-recoverable
         if self.log_level == "WARNING":
             LOG.warning("To be able to see debug logs, you need to change the 'log_level' setting to 'DEBUG' in the core configuration (mycroft.conf)")
-
-
-    def stop(self) -> bool:
-        """Optional action to take when "stop" is requested by the user.
-        This method should return True if it stopped something or
-        False (or None) otherwise.
-        If not relevant to your skill, feel free to remove.
-        """
-        return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ovos-utils>=0.0.38
-ovos-workshop>=0.0.15,<4.0.0
+ovos-workshop>=0.0.15,<7.0.0


### PR DESCRIPTION
now required to implement self.can_stop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version range for a core dependency to allow for newer releases.
- **Refactor**
	- Removed the "stop" feature from the skill, which previously allowed handling of stop requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->