### PR TITLE
chore: migrate skill entrypoint to canonical opm.skill group

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ovos-utils>=0.0.38
 ovos-workshop>=0.0.15,<10.0.0
+ovos-plugin-manager>=2.1.0,<3.0.0

--- a/setup.py
+++ b/setup.py
@@ -85,5 +85,5 @@ setup(
         "end2end": get_requirements("test/requirements-end2end.txt"),
     },
     keywords='ovos skill plugin',
-    entry_points={'ovos.plugin.skill': PLUGIN_ENTRY_POINT}
+    entry_points={'opm.skill': PLUGIN_ENTRY_POINT}
 )


### PR DESCRIPTION
## Summary
ovos-core logs a deprecation warning for this skill:

> old style entrypoint detected for plugin 'ovos-skill-hello-world.openvoiceos' - 'ovos.plugin.skill' should be renamed to 'opm.skill'

This PR renames the `setup.py` entry-point group from `ovos.plugin.skill` to the canonical `opm.skill`, silencing the warning and aligning with current `ovos-plugin-manager` discovery conventions.

## Plugin-manager floor rationale
The `opm.skill` entry-point group is only queried by `ovos-plugin-manager>=2.1.0` — older versions would silently fail to discover this skill at all (no warning, just absence). This repo's existing requirement is `ovos-workshop>=0.0.15,<10.0.0`, and it could not be verified locally whether every version in that wide range transitively floors `ovos-plugin-manager` to `>=2.1.0`. To be safe, this PR adds an explicit `ovos-plugin-manager>=2.1.0,<3.0.0` requirement to `requirements.txt` rather than relying on the transitive chain.

## Verification
Installed the worktree into a throwaway venv and confirmed discovery under the new group:

```
$ python -c "import importlib.metadata as m; [print(e) for e in m.entry_points(group='opm.skill')]"
EntryPoint(name='ovos-skill-hello-world.openvoiceos', value='ovos_skill_hello_world:HelloWorldSkill', group='opm.skill')
```

## Test plan
- [x] Local pip install into a clean venv resolves dependencies without conflict
- [x] `importlib.metadata.entry_points(group='opm.skill')` lists the skill's entry point
- [ ] CI green

---
Authored with Claude Code.