### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,19 @@
 
 # <img src='https://raw.githack.com/FortAwesome/Font-Awesome/master/svgs/solid/smile.svg' card_color='#22a7f0' width='50' height='50' style='vertical-align:bottom'/> Hello World
 
-Introductory Skill so that Skill Authors can see how an OVOS Skill is put together
-
 ## About
 
-This is a basic Hello Word Skill that takes an _Utterance_ from the user and provides a voice response - a _Dialog_. This Skill demonstrates the basic directory and file structure of an OVOS Skill, and is a good first Skill to study if you are interested in developing Skills for the OVOS ecosystem.
+This is an introductory skill for [OpenVoiceOS](https://github.com/OpenVoiceOS). It takes an utterance from the user and speaks a reply. Read its code to see the basic file and directory structure of an OVOS skill. Use it as a starting point when you write your own skill.
 
-## Examples
+## Install
+
+```bash
+pip install ovos-skill-hello-world
+```
+
+## Usage
+
+Say one of these phrases to trigger the skill:
 
 - "Hello world"
 - "How are you?"


### PR DESCRIPTION
Rewrites the README for clarity: adds an explicit Install section and a Usage section listing the example trigger phrases, and tightens the About text. All facts, the license, badges, and credits are unchanged.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to present the skill as an OpenVoiceOS introductory example.
  * Added installation instructions using `pip`.
  * Added usage guidance with supported trigger phrases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->